### PR TITLE
Gali ir likti kaip buvo

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -2,7 +2,7 @@
 
 /* HEADER */
 function stickToTop() {
-    if (window.pageYOffset > 100 ) {
+    if (window.pageYOffset > sticky ) {
       header.classList.add("sticky");
     } else {
       header.classList.remove("sticky");


### PR DESCRIPTION
Iš esmės pas Rimantą buvo padaryta window.pageYOffset > sticky. pas tave buvo window.pageYOffset > 100. Veikia abu variantai. kaip suprantu skirtumas, kad uzdejus sticky, funkcija suveikia iskart paskrolinus, o jei naudojame skaicius galime nusistatyti po kiek praskrolinimo aktyvuotusi funkcija. Taciau del tikslaus paaiskinimo manau verta uzklausti Rimanto.